### PR TITLE
Embed react-use-localstorage in codebase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21026,11 +21026,6 @@
         "prop-types": "^15.6.2"
       }
     },
-    "react-use-localstorage": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/react-use-localstorage/-/react-use-localstorage-3.5.3.tgz",
-      "integrity": "sha512-1oNvJmo72G4v5P9ytJZZTb6ywD3UzWBiainTtfbNlb+U08hc+SOD5HqgiLTKUF0MxGcIR9JSnZGmBttNLXaQYA=="
-    },
     "read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,5 @@
     "tslib": "^2.2.0",
     "typescript": "^4.2.4"
   },
-  "dependencies": {
-    "react-use-localstorage": "^3.5.3"
-  }
+  "dependencies": {}
 }

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -1,13 +1,13 @@
 import { MuiThemeProvider } from "@material-ui/core/styles";
 import React, { useEffect } from "react";
 import Helmet from "react-helmet";
-import useLocalStorage from "react-use-localstorage";
 
 import {
   ExtensionMessageType,
   sendMessageToExtension,
   ThemeChangeMessage,
 } from "../extensions";
+import useLocalStorage from "../tools/useLocalStorage";
 import { Baseline } from "./Baseline";
 import { ThemeContext } from "./context";
 import { createTheme, Themes, ThemeType } from "./createSaleorTheme";
@@ -22,7 +22,7 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({
   defaultTheme = "light",
   overrides = {},
 }) => {
-  const [themeTypeName, setThemeType] = useLocalStorage(
+  const { value: themeTypeName, setValue: setThemeType } = useLocalStorage(
     "macaw-ui-theme",
     defaultTheme
   );

--- a/src/tools/useLocalStorage.ts
+++ b/src/tools/useLocalStorage.ts
@@ -1,0 +1,54 @@
+// Copied directly from
+// https://github.com/dance2die/react-use-localstorage/blob/master/src/index.ts
+// to avoid cjs and esm confusion in jest transformators
+
+import { useCallback, useEffect, useState } from "react";
+
+// We also had to tweak return signature because tuples were bugging
+// typescript parser
+// https://stackoverflow.com/questions/62079477/line-0-parsing-error-cannot-read-property-map-of-undefined
+export interface UseLocalStorage {
+  value: string;
+  setValue: (value: string) => void;
+}
+export default function useLocalStorage(
+  key: string,
+  initialValue: string = ""
+): UseLocalStorage {
+  const [value, setValue] = useState(
+    () => window.localStorage.getItem(key) || initialValue
+  );
+
+  const setItem = (newValue: string) => {
+    setValue(newValue);
+    window.localStorage.setItem(key, newValue);
+  };
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    const newValue = window.localStorage.getItem(key);
+    if (value !== newValue) {
+      setValue(newValue || initialValue);
+    }
+  });
+
+  const handleStorage = useCallback(
+    (event: StorageEvent) => {
+      if (event.key === key && event.newValue !== value) {
+        setValue(event.newValue || initialValue);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [value, key]
+  );
+
+  useEffect(() => {
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, [handleStorage]);
+
+  return {
+    value,
+    setValue: setItem,
+  };
+}


### PR DESCRIPTION
This PR copies code from `react-use-localstorage` because library comes in `esm` file which bugs our other projects in test pipelines. 