### PR TITLE
Add quick table guide

### DIFF
--- a/src/ResponsiveTable/ResponsiveTable.tsx
+++ b/src/ResponsiveTable/ResponsiveTable.tsx
@@ -1,0 +1,24 @@
+import Table from "@material-ui/core/Table";
+import React from "react";
+
+import useStyles from "./styles";
+
+interface ResponsiveTableProps {
+  children: React.ReactNode | React.ReactNodeArray;
+  className?: string;
+  key?: string;
+}
+
+export const ResponsiveTable: React.FC<ResponsiveTableProps> = (props) => {
+  const { children, className } = props;
+
+  const classes = useStyles(props);
+
+  return (
+    <div className={classes.root}>
+      <Table className={className}>{children}</Table>
+    </div>
+  );
+};
+
+ResponsiveTable.displayName = "ResponsiveTable";

--- a/src/ResponsiveTable/index.ts
+++ b/src/ResponsiveTable/index.ts
@@ -1,0 +1,1 @@
+export * from "./ResponsiveTable";

--- a/src/ResponsiveTable/styles.ts
+++ b/src/ResponsiveTable/styles.ts
@@ -1,0 +1,23 @@
+import { makeStyles } from "../theme";
+
+const useStyles = makeStyles(
+  (theme) => ({
+    root: {
+      [theme.breakpoints.up("md")]: {
+        "&& table": {
+          tableLayout: "fixed",
+        },
+      },
+      "& table": {
+        tableLayout: "auto",
+      },
+      overflowX: "auto",
+      width: "100%",
+    },
+  }),
+  {
+    name: "ResponsiveTable",
+  }
+);
+
+export default useStyles;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,3 +9,4 @@ export * from "./SquareButton";
 export * from "./Alert";
 export * from "./Notification";
 export * from "./UserChipMenu";
+export * from "./ResponsiveTable";

--- a/src/theme/createSaleorTheme/overrides/tables.ts
+++ b/src/theme/createSaleorTheme/overrides/tables.ts
@@ -16,8 +16,6 @@ export const tableOverrides = (
   MuiTableCell: {
     body: {
       fontSize: "1.6rem",
-      paddingBottom: 8,
-      paddingTop: 8,
     },
     head: {
       fontSize: "1.4rem",
@@ -42,8 +40,7 @@ export const tableOverrides = (
         },
       },
       borderBottomColor: colors.paperBorder,
-      height: 56,
-      padding: "4px 24px",
+      padding: "16px 24px",
     },
   },
   MuiTablePagination: {

--- a/stories/guideStyles.ts
+++ b/stories/guideStyles.ts
@@ -1,0 +1,25 @@
+import { fade } from "@material-ui/core/styles";
+
+import { makeStyles } from "../src/theme";
+
+const useStyles = makeStyles(
+  (theme) => ({
+    code: {
+      background: fade(theme.palette.secondary.light, 0.1),
+      display: "inline",
+      fontFamily: "monospace",
+      padding: "2px 4px",
+    },
+    headline: {
+      marginBottom: theme.spacing(6),
+    },
+    paragraph: {
+      margin: theme.spacing(3, 0),
+    },
+    sectionHeader: {
+      marginBottom: theme.spacing(3),
+    },
+  }),
+  { name: "Guide" }
+);
+export default useStyles;

--- a/stories/index.stories.tsx
+++ b/stories/index.stories.tsx
@@ -1,5 +1,5 @@
 import { Button, Link, Typography } from "@material-ui/core";
-import { fade, lighten } from "@material-ui/core/styles";
+import { lighten } from "@material-ui/core/styles";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 import SVG from "react-inlinesvg";
@@ -7,6 +7,7 @@ import SVG from "react-inlinesvg";
 import { light, makeStyles, ThemeProvider } from "../src/theme";
 import { Decorator, GuideDecorator } from "../src/utils/Decorator";
 import * as logo from "./assets/macaw-ui-logo.svg";
+import useGuideStyles from "./guideStyles";
 
 const useStyles = makeStyles((theme) => ({
   authors: {
@@ -16,53 +17,39 @@ const useStyles = makeStyles((theme) => ({
   authorsText: {
     fontWeight: 600,
   },
-  code: {
-    background: fade(theme.palette.secondary.light, 0.1),
-    display: "inline",
-    fontFamily: "monospace",
-    padding: "2px 4px",
-  },
   footer: {
     marginTop: theme.spacing(2),
-  },
-  headline: {
-    marginBottom: theme.spacing(6),
   },
   logo: {
     marginBottom: theme.spacing(6),
   },
-  paragraph: {
-    marginBottom: theme.spacing(3),
-  },
   root: {},
-  sectionHeader: {
-    marginBottom: theme.spacing(3),
-  },
 }));
 
 const Default: React.FC = () => {
   const classes = useStyles();
+  const guideClasses = useGuideStyles();
 
   return (
     <div>
       <SVG className={classes.logo} src={logo} />
-      <Typography className={classes.paragraph} component="p">
+      <Typography className={guideClasses.paragraph} component="p">
         Welcome to the MacawUI.
         <br />
         This is an official UI Design Kit for Saleor, a GraphQL-First e-commerce
         platform for perfectionists.
       </Typography>
-      <Typography className={classes.paragraph} component="p">
+      <Typography className={guideClasses.paragraph} component="p">
         You can find most of the elements used in the creation of Saleor’s
         dashboard interface and use it to create designs for your specific
         purposes. Use the left-side navigation to choose between different pages
         on which you can find categorized UI Components.
       </Typography>
-      <Typography className={classes.paragraph} component="p">
+      <Typography className={guideClasses.paragraph} component="p">
         This project is in 'view only' mode, which means that you will have to
         duplicate it to make any changes and create your own solutions.
       </Typography>
-      <Typography className={classes.paragraph} component="p">
+      <Typography className={guideClasses.paragraph} component="p">
         Have a great time working on your designs and empowering your users.
       </Typography>
       <div className={classes.authors}>
@@ -93,30 +80,30 @@ const Default: React.FC = () => {
 };
 
 const CustomTheme: React.FC = () => {
-  const classes = useStyles();
+  const guideClasses = useGuideStyles();
 
   return (
     <div>
-      <Typography className={classes.headline} variant="h1">
+      <Typography className={guideClasses.headline} variant="h1">
         Custom Themes
       </Typography>
-      <Typography className={classes.paragraph} component="p">
+      <Typography className={guideClasses.paragraph} component="p">
         It's possible to override both themes and component internal styles
         using{" "}
-        <Typography color="primary" className={classes.code}>
+        <Typography color="primary" className={guideClasses.code}>
           overrides
         </Typography>{" "}
         and{" "}
-        <Typography color="primary" className={classes.code}>
+        <Typography color="primary" className={guideClasses.code}>
           palettes
         </Typography>{" "}
         props. Macaw-UI uses deep merge algorithm to combine supplied props with
         its own theme.
       </Typography>
-      <Typography className={classes.sectionHeader} variant="h3">
+      <Typography className={guideClasses.sectionHeader} variant="h3">
         Example
       </Typography>
-      <Typography className={classes.paragraph} component="p">
+      <Typography className={guideClasses.paragraph} component="p">
         Let's try to override buttons:
       </Typography>
       <ThemeProvider

--- a/stories/tables.stories.tsx
+++ b/stories/tables.stories.tsx
@@ -30,7 +30,7 @@ const Default: React.FC = () => {
         Tables
       </Typography>
       <Typography className={guideClasses.paragraph} component="p">
-        Tables play huge part in creating dashboards. If you're building Saleor
+        Tables play a huge part in creating dashboards. If you're building a Saleor
         Extension, it's probably what you're going to use for displaying tabular
         data. In Saleor Dashboard, we build our tables like this:
       </Typography>

--- a/stories/tables.stories.tsx
+++ b/stories/tables.stories.tsx
@@ -1,0 +1,101 @@
+import {
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@material-ui/core";
+import Skeleton from "@material-ui/lab/Skeleton";
+import { storiesOf } from "@storybook/react";
+import React from "react";
+
+import { ResponsiveTable } from "../src";
+import { makeStyles } from "../src/theme";
+import { Decorator, GuideDecorator } from "../src/utils/Decorator";
+import useGuideStyles from "./guideStyles";
+
+const useStyles = makeStyles((theme) => ({
+  colCalories: {
+    width: 180,
+  },
+}));
+
+const Default: React.FC = () => {
+  const classes = useStyles();
+  const guideClasses = useGuideStyles();
+
+  return (
+    <div>
+      <Typography className={guideClasses.headline} variant="h1">
+        Tables
+      </Typography>
+      <Typography className={guideClasses.paragraph} component="p">
+        Tables play huge part in creating dashboards. If you're building Saleor
+        Extension, it's probably what you're going to use for displaying tabular
+        data. In Saleor Dashboard, we build our tables like this:
+      </Typography>
+
+      <ResponsiveTable>
+        <colgroup>
+          <col />
+          <col className={classes.colCalories} />
+        </colgroup>
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell>Calories (per 100g)</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow>
+            <TableCell>Baked Potato</TableCell>
+            <TableCell>93 kcal</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>French Fries</TableCell>
+            <TableCell>312 kcal</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Cheddar</TableCell>
+            <TableCell>403 kcal</TableCell>
+          </TableRow>
+        </TableBody>
+      </ResponsiveTable>
+
+      <Typography className={guideClasses.paragraph} component="p">
+        When our data is not ready, either calculating or fetching, we display{" "}
+        <Typography className={guideClasses.code}>
+          &lt;Skeleton /&gt;
+        </Typography>{" "}
+        component that indicates its loading status:
+      </Typography>
+      <ResponsiveTable>
+        <colgroup>
+          <col />
+          <col className={classes.colCalories} />
+        </colgroup>
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell>Calories (per 100g)</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow>
+            <TableCell>
+              <Skeleton />
+            </TableCell>
+            <TableCell>
+              <Skeleton />
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </ResponsiveTable>
+    </div>
+  );
+};
+
+storiesOf("Tables", module)
+  .addDecorator(Decorator)
+  .addDecorator(GuideDecorator)
+  .add("default", () => <Default />);


### PR DESCRIPTION
This PR adds quick table usage demonstration and introduces `ResponsiveTable` component as well as changes the way `TableCell` is sized.
Note: built on top of #22 

![Screenshot from 2021-07-07 15-18-52](https://user-images.githubusercontent.com/6833443/124765975-c8801f80-df36-11eb-9c5e-c22eabb51b20.png)
